### PR TITLE
Merge develop into main

### DIFF
--- a/src/blizzard-world-winter.workshop
+++ b/src/blizzard-world-winter.workshop
@@ -2,7 +2,7 @@ settings
 {
 	main
 	{
-		Description: "Blizzard World (Winter) \n\nv2026.05.31-0 \n\nLatest Code: GMWRF"
+		Description: "Blizzard World (Winter) \n\nv2026.05.31-1 \n\nLatest Code: GMWRF"
 		Mode Name: "Ball Parkour ● ballkour.com"
 	}
 

--- a/src/blizzard-world-winter.workshop
+++ b/src/blizzard-world-winter.workshop
@@ -1474,7 +1474,7 @@ rule("19.1: Checkpoint Completed (No Skipping)")
 		Event Player.isRunLoaded == True;
 		Event Player.isInFreemode == False;
 		Event Player.isRunPaused == False;
-		(Is On Ground(Event Player) || Event Player.cpData[10] || (Altitude Of(Event Player) < 0.05 && !Event Player.cpData[14])) == True;
+		(Is On Ground(Event Player) || Event Player.cpData[10] || (Altitude Of(Event Player) < 0.01 && !Event Player.cpData[14])) == True;
 		Distance Between(Position Of(Event Player), Event Player.cpData[6]) <= Event Player.cpData[7];
 	}
 

--- a/src/watchpoint-gibraltar.workshop
+++ b/src/watchpoint-gibraltar.workshop
@@ -2,7 +2,7 @@ settings
 {
 	main
 	{
-		Description: "Watchpoint: Gibraltar \n\nv2026.05.31-0 \n\nLatest Code: 59W28"
+		Description: "Watchpoint: Gibraltar \n\nv2026.05.31-1 \n\nLatest Code: 59W28"
 		Mode Name: "Ball Parkour ● ballkour.com"
 	}
 

--- a/src/watchpoint-gibraltar.workshop
+++ b/src/watchpoint-gibraltar.workshop
@@ -1445,7 +1445,7 @@ rule("19.1: Checkpoint Completed (No Skipping)")
 		Event Player.isRunLoaded == True;
 		Event Player.isInFreemode == False;
 		Event Player.isRunPaused == False;
-		(Is On Ground(Event Player) || Event Player.cpData[10] || (Altitude Of(Event Player) < 0.05 && !Event Player.cpData[14])) == True;
+		(Is On Ground(Event Player) || Event Player.cpData[10] || (Altitude Of(Event Player) < 0.01 && !Event Player.cpData[14])) == True;
 		Distance Between(Position Of(Event Player), Event Player.cpData[6]) <= Event Player.cpData[7];
 	}
 


### PR DESCRIPTION
## Changes

- fix: make CP not register success if height is too far above ground (#203)
  - Prevents "unstable" CP completions where you're not actually stable with the ground but it registers you as completing it.
  - This does not seem to affect the CPs where you glide on, such as WP: Gibraltar's 5th CP.