### PR TITLE
fix: server not auto-restarting properly

### DIFF
--- a/src/main.opy
+++ b/src/main.opy
@@ -20,10 +20,8 @@ rule "6.1: Initialize Match":
     playersUnpaused = 0
 
 rule "6.2: Start Elapsed Timer":
-    @Condition settings_[1] == true
-    
     chaseAtRate(elapsedTime, 14340, 1)
-    if not settings_[0]:
+    if settings_[1] and not settings_[0]:
         elapsedTimeFormatted = "{0}:{1}:{2}".format(floor(elapsedTime / 3600), (elapsedTime % 3600 / 60 + 100).substring(1, 2), (elapsedTime % 60 + 100).substring(1, 9999)) if elapsedTime >= 3600 else "{0}:{1}".format(floor(elapsedTime / 60), (elapsedTime % 60 + 100).substring(1, 9999)) if elapsedTime >= 60 else "{0}.{1}".format(floor(elapsedTime), (round(elapsedTime % 1 * 100) + 100).substring(1, 2))
         wait(0.1)
         loop()
@@ -983,7 +981,7 @@ rule "21.8: Lobby Input":
 rule "23.1: Auto-Restart Server":
     @SuppressWarnings w_ow2_rule_condition_chase
     #3hr29min in
-    @Condition elapsedTime == 12540
+    @Condition elapsedTime >= 12540
     
     chaseAtRate(elapsedTime, 99999999, 1)
     bigMessage(getAllPlayers(), "Server restart: \n30min")


### PR DESCRIPTION
* if lobby stats are turned off, server now auto-restarts
* change compararison operator in case timer doesn't land on .00